### PR TITLE
Add support for wavshare RPI2040

### DIFF
--- a/software/include/common_dvi_pin_configs.h
+++ b/software/include/common_dvi_pin_configs.h
@@ -28,6 +28,17 @@ static const struct dvi_serialiser_cfg picodvi_reva_dvi_cfg = {
 	.invert_diffpairs = true
 };
 
+// AMY-DVI board, for getting HDMI from the RP2350 FPGA development platform,
+// again a cursed board that only a couple of people in the world possess:
+static const struct dvi_serialiser_cfg amy_dvi_cfg = {
+	.pio = DVI_DEFAULT_PIO_INST,
+	.sm_tmds = {0, 1, 2},
+	.pins_tmds = {14, 16, 18},
+	.pins_clk = 12,
+	.invert_diffpairs = true
+};
+
+
 // The not-HDMI socket on Rev C PicoDVI boards
 // (we don't talk about Rev B)
 static const struct dvi_serialiser_cfg picodvi_dvi_cfg = {
@@ -69,15 +80,6 @@ static const struct dvi_serialiser_cfg pico_sock_cfg = {
 	.invert_diffpairs = false
 };
 
-// pico-RGB2HDMI
-// static const struct dvi_serialiser_cfg pico_sock_cfg = {
-//         .pio = pio0,
-//         .sm_tmds = {0, 1, 2},
-//         .pins_tmds = {5, 7, 9},
-//         .pins_clk = 3,
-//         .invert_diffpairs = true
-//     };
-
 // The HDMI socket on Pimoroni Pico Demo HDMI
 // (we would talk about rev B if we had a rev B...)
 static const struct dvi_serialiser_cfg pimoroni_demo_hdmi_cfg = {
@@ -95,6 +97,24 @@ static const struct dvi_serialiser_cfg not_hdmi_featherwing_cfg = {
 	.pins_tmds = {11, 9, 7},
 	.pins_clk = 24,
 	.invert_diffpairs = true
+};
+
+// Adafruit Feather RP2040 DVI
+static const struct dvi_serialiser_cfg adafruit_feather_dvi_cfg = {
+	.pio = pio0,
+	.sm_tmds = {0, 1, 2},
+	.pins_tmds = {18, 20, 22},
+	.pins_clk = 16,
+	.invert_diffpairs = true
+};
+
+// Waveshare RP2040-PiZero
+static const struct dvi_serialiser_cfg waveshare_rp2040_pizero = {
+	.pio = DVI_DEFAULT_PIO_INST,
+	.sm_tmds = {0, 1, 2},
+	.pins_tmds = {26, 24, 22},
+	.pins_clk = 28,
+	.invert_diffpairs = false
 };
 
 #endif


### PR DESCRIPTION
Add support for wavshare RPI2040

All of the example apps use the DVI_DEFAULT_SERIAL_CONFIG from this header to select their pin configuration, which has a default value of pico_sock_cfg. You can pass -DDVI_DEFAULT_SERIAL_CONFIG=some_other_board to cmake to override this default, so that the example apps will be built with a different serial configuration.